### PR TITLE
fix: frames no longer drop rest of message

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,9 @@
 (test
  (name frame_serde_test)
+ (modules frame_serde_test)
  (libraries trail qcheck))
+
+(test
+  (name multi_frame_test)
+  (modules multi_frame_test)
+  (libraries trail alcotest))

--- a/test/multi_frame_test.ml
+++ b/test/multi_frame_test.ml
@@ -1,0 +1,53 @@
+open Riot
+
+let test_single_pong () =
+  let ser = Trail.Frame.Request.serialize Ping in
+  let raw = Bytestring.to_string ser in
+  let res = Trail.Frame.Response.deserialize raw in
+  match res with
+  | Some (`ok Ping, "") -> ()
+  | _ -> Alcotest.fail "Invalid response"
+
+let test_pong_with_other_message () =
+  let ser = Trail.Frame.Response.serialize Ping in
+  (* let bytes = Bytestring.to_string ser in *)
+  (* let repr = *)
+  (*   String.fold_left (fun acc b -> acc ^ Fmt.str "%d " (Char.code b)) "" bytes *)
+  (* in *)
+  (* failwith (Fmt.str "BYTES -> %s@." repr) *)
+  let raw = Bytestring.to_string ser in
+  (* Add a null byte separator *)
+  let raw = raw ^ Bytes.to_string Bytes.empty in
+  (* Append a hello world text *)
+  let text =
+    Trail.Frame.Response.serialize
+      (Text { fin = true; compressed = false; payload = "hello, world" })
+    |> Bytestring.to_string
+  in
+  let raw = raw ^ text in
+  let res = Trail.Frame.Response.deserialize raw in
+  let text_repr =
+    String.fold_left (fun acc b -> acc ^ Fmt.str "%d " (Char.code b)) "" text
+  in
+  match res with
+  | Some (`ok Ping, remaining) when remaining = text -> ()
+  | Some (`ok Ping, _) ->
+      Alcotest.fail (Fmt.str "Expected remaining = %s | %s" text text_repr)
+  | _ -> Alcotest.fail "Invalid response"
+
+let () =
+  Riot.run @@ fun () ->
+  let _ = Logger.start () in
+  Logger.set_log_level (Some Debug);
+
+  let open Alcotest in
+  run "Utils"
+    [
+      ( "start",
+        [
+          test_case "alcotest" `Quick (fun () ->
+              Alcotest.(check int "1 + 1 = 2" 2 (1 + 1)));
+          test_case "single pong" `Quick test_single_pong;
+          test_case "pong + other msg" `Quick test_pong_with_other_message;
+        ] );
+    ]

--- a/trail/frame.ml
+++ b/trail/frame.ml
@@ -125,9 +125,11 @@ module Request = struct
        length : 64;
        mask : 32;
        payload : Int64.(mul length 8L |> to_int) : string;
-       rest : -1 : string |}
+       rest : -1 : bitstring |}
       when max_frame_size = 0 || Int64.(length <= of_int max_frame_size) ->
-        Some (make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload, rest)
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
     | {| fin : 1;
        compressed : 1;
        rsv : 2;
@@ -137,9 +139,11 @@ module Request = struct
        length : 16 : int;
        mask : 32 : int;
        payload : (length * 8) : string;
-       rest : -1 : string |}
+       rest : -1 : bitstring |}
       when max_frame_size = 0 || length <= max_frame_size ->
-        Some (make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload, rest)
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
     | {| fin : 1;
        compressed : 1;
        rsv : 2;
@@ -148,10 +152,13 @@ module Request = struct
        length : 7 : int;
        mask : 32 : int;
        payload : (length * 8) : string;
-       rest : -1 : string |}
+       rest : -1 : bitstring |}
       when length <= 125 && (max_frame_size == 0 || length <= max_frame_size) ->
-        Some (make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload, rest)
-    | {| _data : -1 : string  |} -> Some (`more (Bytestring.of_string data), "")
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| _data : -1 : bitstring  |} ->
+        Some (`more (Bytestring.of_string data), "")
 
   let serialize (t : t) =
     let opcode, fin, compressed, mask, payload =
@@ -204,9 +211,11 @@ module Response = struct
        length : 64;
        mask : 32;
        payload : Int64.(mul length 8L |> to_int) : string;
-       rest : -1 : string |}
+       rest : -1 : bitstring |}
       ->
-        Some (make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload, rest)
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
     | {| fin : 1;
        compressed : 1;
        rsv : 2;
@@ -215,9 +224,11 @@ module Response = struct
        pad2 : 7 : check( pad2 = 127 );
        length : 64;
        payload : Int64.(mul length 8L |> to_int) : string;
-       rest : -1 : string |}
+       rest : -1 : bitstring |}
       ->
-        Some (make ~masked ~fin ~compressed ~rsv ~opcode ~mask:0l ~payload, rest)
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask:0l ~payload,
+            Bitstring.string_of_bitstring rest )
     | {| fin : 1;
        compressed : 1;
        rsv : 2;
@@ -227,9 +238,11 @@ module Response = struct
        length : 16 : int;
        mask : 32 : int;
        payload : (length * 8) : string;
-       rest : -1 : string |}
+       rest : -1 : bitstring |}
       ->
-        Some (make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload, rest)
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
     | {| fin : 1;
        compressed : 1;
        rsv : 2;
@@ -238,9 +251,11 @@ module Response = struct
        pad2 : 7 : check( pad2 = 126 );
        length : 16 : int;
        payload : (length * 8) : string;
-       rest : -1 : string |}
+       rest : -1 : bitstring |}
       ->
-        Some (make ~masked ~fin ~compressed ~rsv ~opcode ~mask:0l ~payload, rest)
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask:0l ~payload,
+            Bitstring.string_of_bitstring rest )
     | {| fin : 1;
        compressed : 1;
        rsv : 2;
@@ -249,9 +264,11 @@ module Response = struct
        length : 7 : int;
        mask : 32 : int;
        payload : (length * 8) : string;
-       rest : -1 : string |}
+       rest : -1 : bitstring |}
       when length >= 0 && length <= 125 ->
-        Some (make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload, rest)
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask ~payload,
+            Bitstring.string_of_bitstring rest )
     | {| fin : 1;
        compressed : 1;
        rsv : 2;
@@ -259,10 +276,13 @@ module Response = struct
        masked : 1 : check (masked = false);
        length : 7 : int;
        payload : (length * 8) : string;
-       rest : -1 : string |}
+       rest : -1 : bitstring |}
       when length >= 0 && length <= 125 ->
-        Some (make ~masked ~fin ~compressed ~rsv ~opcode ~mask:0l ~payload, rest)
-    | {| _data : -1 : string  |} -> Some (`more (Bytestring.of_string data), "")
+        Some
+          ( make ~masked ~fin ~compressed ~rsv ~opcode ~mask:0l ~payload,
+            Bitstring.string_of_bitstring rest )
+    | {| _data : -1 : bitstring  |} ->
+        Some (`more (Bytestring.of_string data), "")
 
   let serialize (t : t) =
     let compressed = false in


### PR DESCRIPTION
According to what I could find in the docs,
only bitstrings are allowed to take a -1
length and then match the rest of the bitstring.

So the string was always just empty and no "rest"
was ever found. This caused messages to be dropped
if they arrived in the same packet (for example,
only deserialize the Ping message. Which is bad).

(Feel free to change however you'd like, if you don't
like the test or implementation)